### PR TITLE
Smaller thumbnail size for participants who are not streaming/sharing screen.

### DIFF
--- a/css/filmstrip/_tile_view.scss
+++ b/css/filmstrip/_tile_view.scss
@@ -92,6 +92,11 @@
         video {
             object-fit: contain;
         }
+
+        #videosDelimiter {
+            order: 10;
+            width: 100%;
+        }
     }
 
     .has-overflow#filmstripRemoteVideosContainer {
@@ -110,5 +115,13 @@
      */
     .has-overflow #localVideoContainer {
         margin-bottom: 100px !important;
+    }
+
+    .without-camera {
+        order: 11;
+    }
+
+    .with-camera {
+        order: 1;
     }
 }

--- a/modules/UI/videolayout/Filmstrip.js
+++ b/modules/UI/videolayout/Filmstrip.js
@@ -1,6 +1,9 @@
 /* global $, APP, interfaceConfig */
 
-import { getVerticalFilmstripVisibleAreaWidth, isFilmstripVisible } from '../../../react/features/filmstrip';
+import {
+    getVerticalFilmstripVisibleAreaWidth,
+    isFilmstripVisible
+} from '../../../react/features/filmstrip';
 
 const Filmstrip = {
     /**
@@ -39,30 +42,55 @@ const Filmstrip = {
         const thumbs = this._getThumbs(!forceUpdate);
         const avatarSize = height / 2;
 
-        if (thumbs.localThumb) {
-            thumbs.localThumb.css({
-                'padding-top': '',
-                height: `${height}px`,
-                'min-height': `${height}px`,
-                'min-width': `${width}px`,
-                width: `${width}px`
-            });
-        }
-
-        if (thumbs.remoteThumbs) {
-            thumbs.remoteThumbs.css({
-                'padding-top': '',
-                height: `${height}px`,
-                'min-height': `${height}px`,
-                'min-width': `${width}px`,
-                width: `${width}px`
-            });
-        }
+        const bigVideoCSS = {
+            'padding-top': '',
+            height: `${height}px`,
+            'min-height': `${height}px`,
+            'min-width': `${width}px`,
+            width: `${width}px`
+        };
 
         $('.avatar-container').css({
             height: `${avatarSize}px`,
             width: `${avatarSize}px`
         });
+
+        [ ...thumbs.remoteThumbs, ...thumbs.localThumb ].forEach(videoThumb => {
+            const $thumb = $(videoThumb);
+
+            // Smaller video
+            if (!$thumb.hasClass('without-camera')) {
+                $thumb.css(bigVideoCSS);
+
+                return;
+            }
+
+            const ratio = width / height;
+
+            // Everything is relative to vw ; width is 20%
+            const smallVideoWidthPercent = 20;
+            const smallVideoHeight = smallVideoWidthPercent / ratio;
+            const smallVideoAvatar = smallVideoHeight / 2;
+
+            $thumb.css({
+                'padding-top': '',
+                height: `${smallVideoHeight}vw`,
+                'min-height': `${smallVideoHeight}vw`,
+                'min-width': `${smallVideoWidthPercent}vw`,
+                width: `${smallVideoWidthPercent}vw`
+            });
+            $thumb.find('.avatar-container')
+                .css({
+                    height: `${smallVideoAvatar}vw`,
+                    width: `${smallVideoAvatar}vw`
+                });
+        });
+
+        // If i am the only participant
+        // Make my thumbnail a large videо
+        if (thumbs.remoteThumbs.length === 0) {
+            thumbs.localThumb.css(bigVideoCSS);
+        }
     },
 
     /**

--- a/modules/UI/videolayout/Filmstrip.js
+++ b/modules/UI/videolayout/Filmstrip.js
@@ -59,7 +59,7 @@ const Filmstrip = {
             const $thumb = $(videoThumb);
 
             // Smaller video
-            if (!$thumb.hasClass('without-camera')) {
+            if ($thumb.hasClass('with-camera')) {
                 $thumb.css(bigVideoCSS);
 
                 return;

--- a/modules/UI/videolayout/SmallVideo.js
+++ b/modules/UI/videolayout/SmallVideo.js
@@ -20,13 +20,15 @@ import { DisplayName } from '../../../react/features/display-name';
 import {
     DominantSpeakerIndicator,
     RaisedHandIndicator,
+    setTileViewDimensions,
     StatusIndicators
 } from '../../../react/features/filmstrip';
 import {
     LAYOUTS,
     getCurrentLayout,
     setTileView,
-    shouldDisplayTileView
+    shouldDisplayTileView,
+    getTileViewGridDimensions
 } from '../../../react/features/video-layout';
 /* eslint-enable no-unused-vars */
 
@@ -556,8 +558,44 @@ export default class SmallVideo {
         }
 
         if (this.displayMode !== oldDisplayMode) {
+            this.reArrangeVideos();
             logger.debug(`Displaying ${displayModeString} for ${this.id}, data: [${JSON.stringify(displayModeInput)}]`);
         }
+    }
+
+    /**
+     * Change the order of the element, based on displayMode
+     * If is sharing screen/streaming order should be < 10
+     * Else order > 10
+     * Also adds special className 'without-camera' to apply
+     * different styles (smaller width and height)
+     */
+    reArrangeVideos() {
+        if (this.displayMode === DISPLAY_VIDEO || this.displayMode === DISPLAY_VIDEO_WITH_NAME) {
+            if (this.isLocal) {
+                $(this.container.parentNode).toggleClass('without-camera', false);
+                $(this.container.parentNode).toggleClass('with-camera', true);
+            }
+            this.$container.toggleClass('without-camera', false);
+            this.$container.toggleClass('with-camera', true);
+        }
+        if (this.displayMode === DISPLAY_AVATAR_WITH_NAME || this.displayMode === DISPLAY_AVATAR) {
+            if (this.isLocal) {
+                $(this.container.parentNode).toggleClass('with-camera', false);
+                $(this.container.parentNode).toggleClass('without-camera', true);
+            }
+            this.$container.toggleClass('with-camera', false);
+            this.$container.toggleClass('without-camera', true);
+        }
+
+        // Force recalculation of the grid and rerender of thumbnails
+        const gridDimensions = getTileViewGridDimensions(APP.store.getState());
+        const { clientHeight, clientWidth } = APP.store.getState()['features/base/responsive-ui'];
+
+        APP.store.dispatch(setTileViewDimensions(gridDimensions, {
+            clientHeight,
+            clientWidth
+        }));
     }
 
     /**

--- a/react/features/filmstrip/components/web/Filmstrip.js
+++ b/react/features/filmstrip/components/web/Filmstrip.js
@@ -242,6 +242,8 @@ class Filmstrip extends Component <Props> {
                             onMouseOver = { this._onMouseOver }
                             style = { filmstripRemoteVideosContainerStyle }>
                             <div id = 'localVideoTileViewContainer' />
+                            {/* Empty line between smaller and bigger videos */}
+                            <div id = 'videosDelimiter' />
                         </div>
                     </div>
                 </div>

--- a/react/features/video-layout/functions.js
+++ b/react/features/video-layout/functions.js
@@ -46,10 +46,11 @@ export function getMaxColumnCount() {
  * rows, and visible rows (the rest should overflow) for the tile view layout.
  */
 export function getTileViewGridDimensions(state: Object, maxColumns: number = getMaxColumnCount()) {
-    // When in tile view mode, we must discount ourselves (the local participant) because our
-    // tile is not visible.
-    const { iAmRecorder } = state['features/base/config'];
-    const numberOfParticipants = state['features/base/participants'].length - (iAmRecorder ? 1 : 0);
+
+    // This is needed to calculate the size of large videos, therefore, numberOfParticipants
+    // should be only the number of people who are streaming
+    const streamingParticipantsSelector = 'span.videocontainer:not(.without-camera)';
+    const numberOfParticipants = document.querySelectorAll(streamingParticipantsSelector).length || 1;
 
     const columnsToMaintainASquare = Math.ceil(Math.sqrt(numberOfParticipants));
     const columns = Math.min(columnsToMaintainASquare, maxColumns);


### PR DESCRIPTION
Until now, the width and height of thumbnails in tile view are calculated as follows:
Based on number of participants, a grid is generated, trying to maintain a square.
The new smaller thumbnails, are excluded from this grid.
* Changed the grid of thumbnails to be calculated only based on streaming participants
* Added different style for thumbnails of non streaming participants, which is 15% of the width of the client's viewport and height calculated based on other videos ratio.