### PR TITLE
Propagate participant ak address

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -27,6 +27,7 @@ import {
     AVATAR_ID_COMMAND,
     AVATAR_URL_COMMAND,
     EMAIL_COMMAND,
+    AK_ADDRESS_COMMAND,
     authStatusChanged,
     commonUserJoinedHandling,
     commonUserLeftHandling,
@@ -176,7 +177,8 @@ const commands = {
     CUSTOM_ROLE: 'custom-role',
     EMAIL: EMAIL_COMMAND,
     ETHERPAD: 'etherpad',
-    SHARED_VIDEO: 'shared-video'
+    SHARED_VIDEO: 'shared-video',
+    AK_ADDRESS: AK_ADDRESS_COMMAND
 };
 
 /**
@@ -2317,6 +2319,17 @@ export default {
                         conference: room,
                         id: from,
                         avatarID: data.value
+                    }));
+            });
+
+        room.addCommandListener(
+            this.commands.defaults.AK_ADDRESS,
+            (data, from) => {
+                APP.store.dispatch(
+                    participantUpdated({
+                        conference: room,
+                        id: from,
+                        akAddress: data.value
                     }));
             });
 

--- a/react/features/base/conference/constants.js
+++ b/react/features/base/conference/constants.js
@@ -20,6 +20,13 @@ export const AVATAR_URL_COMMAND = 'avatar-url';
 export const EMAIL_COMMAND = 'email';
 
 /**
+ * The command type for updating a participant's akAddress.
+ *
+ * @type {string}
+ */
+export const AK_ADDRESS_COMMAND = 'ak-address';
+
+/**
  * The name of the {@code JitsiConference} property which identifies the URL of
  * the conference represented by the {@code JitsiConference} instance.
  *

--- a/react/features/base/conference/functions.js
+++ b/react/features/base/conference/functions.js
@@ -17,6 +17,7 @@ import {
     AVATAR_ID_COMMAND,
     AVATAR_URL_COMMAND,
     EMAIL_COMMAND,
+    AK_ADDRESS_COMMAND,
     JITSI_CONFERENCE_URL_KEY,
     VIDEO_QUALITY_LEVELS
 } from './constants';
@@ -353,7 +354,8 @@ export function sendLocalParticipant(
         avatarURL,
         email,
         features,
-        name
+        name,
+        akAddress
     } = getLocalParticipant(stateful);
 
     avatarID && conference.sendCommand(AVATAR_ID_COMMAND, {
@@ -364,6 +366,9 @@ export function sendLocalParticipant(
     });
     email && conference.sendCommand(EMAIL_COMMAND, {
         value: email
+    });
+    akAddress && conference.sendCommand(AK_ADDRESS_COMMAND, {
+        value: akAddress
     });
 
     if (features && features['screen-sharing'] === 'true') {

--- a/react/features/base/jwt/middleware.js
+++ b/react/features/base/jwt/middleware.js
@@ -8,6 +8,8 @@ import {
     getLocalParticipant,
     participantUpdated
 } from '../participants';
+// eslint-disable-next-line import/order
+import { AK_ADDRESS_COMMAND } from '../conference';
 import { MiddlewareRegistry } from '../redux';
 
 import { SET_JWT } from './actionTypes';
@@ -42,7 +44,7 @@ MiddlewareRegistry.register(store => next => action => {
 });
 
 /**
- * Overwrites the properties {@code avatarURL}, {@code email}, and {@code name}
+ * Overwrites the properties {@code avatarURL}, {@code email},{@code name} and {@code akAddress}
  * of the local participant stored in the redux state base/participants.
  *
  * @param {Store} store - The redux store.
@@ -54,10 +56,10 @@ MiddlewareRegistry.register(store => next => action => {
  */
 function _overwriteLocalParticipant(
         { dispatch, getState },
-        { avatarURL, email, name, features }) {
+        { avatarURL, email, name, features, akAddress }) {
     let localParticipant;
 
-    if ((avatarURL || email || name)
+    if ((avatarURL || email || name || akAddress)
             && (localParticipant = getLocalParticipant(getState))) {
         const newProperties: Object = {
             id: localParticipant.id,
@@ -75,6 +77,9 @@ function _overwriteLocalParticipant(
         }
         if (features) {
             newProperties.features = features;
+        }
+        if (akAddress) {
+            newProperties.akAddress = akAddress;
         }
         dispatch(participantUpdated(newProperties));
     }
@@ -152,6 +157,17 @@ function _setJWT(store, next, action) {
                     user && _overwriteLocalParticipant(
                         store, { ...user,
                             features: context.features });
+                    const { akAddress = '' } = user;
+                    const { conference } = APP;
+
+
+                    // incase participant joined before jwt token is gotten
+                    // eslint-disable-next-line max-depth
+                    if (akAddress && conference && conference.isJoined()) {
+                        conference.commands.sendCommand(AK_ADDRESS_COMMAND, {
+                            value: akAddress
+                        });
+                    }
                 }
             }
         } else if (typeof APP === 'undefined') {
@@ -184,10 +200,10 @@ function _setJWT(store, next, action) {
  */
 function _undoOverwriteLocalParticipant(
         { dispatch, getState },
-        { avatarURL, name, email }) {
+        { avatarURL, name, email, akAddress }) {
     let localParticipant;
 
-    if ((avatarURL || name || email)
+    if ((avatarURL || name || email || akAddress)
             && (localParticipant = getLocalParticipant(getState))) {
         const newProperties: Object = {
             id: localParticipant.id,
@@ -202,6 +218,9 @@ function _undoOverwriteLocalParticipant(
         }
         if (name === localParticipant.name) {
             newProperties.name = undefined;
+        }
+        if (akAddress === localParticipant.akAddress) {
+            newProperties.akAddress = undefined;
         }
         newProperties.features = undefined;
 
@@ -219,10 +238,11 @@ function _undoOverwriteLocalParticipant(
  *     avatarURL: ?string,
  *     email: ?string,
  *     id: ?string,
- *     name: ?string
+ *     name: ?string,
+ *     akAddress: ?string
  * }}
  */
-function _user2participant({ avatar, avatarUrl, email, id, name }) {
+function _user2participant({ avatar, avatarUrl, email, id, name, address }) {
     const participant = {};
 
     if (typeof avatarUrl === 'string') {
@@ -238,6 +258,9 @@ function _user2participant({ avatar, avatarUrl, email, id, name }) {
     }
     if (typeof name === 'string') {
         participant.name = name.trim();
+    }
+    if (typeof address === 'string') {
+        participant.akAddress = address.trim();
     }
 
     return Object.keys(participant).length ? participant : undefined;

--- a/react/features/base/participants/reducer.js
+++ b/react/features/base/participants/reducer.js
@@ -181,6 +181,7 @@ function _participant(state: Object = {}, action) {
  */
 function _participantJoined({ participant }) {
     const {
+        akAddress,
         avatarID,
         avatarURL,
         botType,
@@ -211,6 +212,7 @@ function _participantJoined({ participant }) {
     }
 
     return {
+        akAddress,
         avatarID,
         avatarURL,
         botType,


### PR DESCRIPTION
This PR propagates a participant wallets ak-address to every other participants in conference as `akAddress`.
Closes #117 