### PR TITLE
CI convert branch name to lower

### DIFF
--- a/.github/workflows/branch_deploy.yml
+++ b/.github/workflows/branch_deploy.yml
@@ -10,7 +10,7 @@ jobs:
       # strip 'refs/heads/' from GITHUB_REF and export as ${{ steps.get_branch.outputs.branch }}
       - name: Get branch name
         id: get_branch
-        run: echo "::set-output name=branch::${GITHUB_REF##*/}"
+        run: echo "::set-output name=branch::$(echo ${GITHUB_REF##*/}|tr '[:upper:]' '[:lower:]')"
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:

--- a/.github/workflows/branch_url.yml
+++ b/.github/workflows/branch_url.yml
@@ -12,7 +12,7 @@ jobs:
         env:
           BRANCH_REF: ${{ github.head_ref }}
         id: get_branch
-        run: echo "::set-output name=branch::${BRANCH_REF##*/}"
+        run: echo "::set-output name=branch::$(echo ${BRANCH_REF##*/}|tr '[:upper:]' '[:lower:]')"
       - name: Publish url in PR
         uses: unsplash/comment-on-pr@master
         env:

--- a/.github/workflows/delete_branch.yml
+++ b/.github/workflows/delete_branch.yml
@@ -15,7 +15,7 @@ jobs:
         env:
           BRANCH_REF: ${{ github.head_ref }}
         id: get_branch
-        run: echo "::set-output name=branch::${BRANCH_REF##*/}"
+        run: echo "::set-output name=branch::$(echo ${GITHUB_REF##*/}|tr '[:upper:]' '[:lower:]')"
       - name: Remove deployed branch and restart services
         uses: JimCronqvist/action-ssh@master
         with:


### PR DESCRIPTION
Branch names should be to lowercase because they are used as subdomains, which are always lowercase
Deployment will happen in the proper directory, but nginx will try to access it lowercased (as it is in the subdomain) and it might return 404 if they do not match