### PR TITLE
Pinned participant on the top [on hold]

### DIFF
--- a/css/filmstrip/_small_video.scss
+++ b/css/filmstrip/_small_video.scss
@@ -17,6 +17,7 @@
         border: $thumbnailVideoBorder solid $videoThumbnailSelected;
         box-shadow: inset 0 0 3px $videoThumbnailSelected,
         0 0 3px $videoThumbnailSelected;
+        order: -1;
     }
 
     .remotevideomenu > .icon-menu {


### PR DESCRIPTION
Description from traceability matrix: _Pin participant for self – should put the user thumbnail on top of the others only for you_