### PR TITLE
hasWallet is true only if it's found not for the deeplink auth

### DIFF
--- a/react/features/conference/components/web/Conference.js
+++ b/react/features/conference/components/web/Conference.js
@@ -152,7 +152,10 @@ class Conference extends AbstractConference<Props, *> {
 
         if (!addressParam && !signatureParam) {
             initClient().then(() => {
-                scanForWallets(this._sign);
+                scanForWallets(() => {
+                    this._sign();
+                    this.props.dispatch(walletFound());
+                });
             });
         }
 
@@ -288,7 +291,6 @@ class Conference extends AbstractConference<Props, *> {
         // if user will click the "reject" button the code will stops before that line
         this.props.dispatch(setJWT(token));
         this.setState({ showDeeplink: false });
-        APP.store.dispatch(walletFound());
     }
 
     /**


### PR DESCRIPTION
~~@Liubov-crypto if you don't mind, please provide some info here or at issue.~~

When we open jitsi `without iframe directly` and use `login with Superhero` button at Prejoin in that case our app think that we has wallet, but in general we don't client inited and that's why we get error on `tippting` Throws an error `Init sdk first`

So at this PR hasWallet is true only when we use sdk and found a wallet with detector, not when we login with deeplink.